### PR TITLE
change max1d to usual default values in examples where set in setrun.py

### DIFF
--- a/examples/advection_2d_square/setrun.py
+++ b/examples/advection_2d_square/setrun.py
@@ -270,7 +270,7 @@ def setrun(claw_pkg='amrclaw'):
     amrdata = rundata.amrdata
 
     # max1d controls size of grids
-    amrdata.max1d = 120
+    amrdata.max1d = 60
 
     # max number of refinement levels:
     amrdata.amr_levels_max = 3

--- a/examples/euler_1d_wcblast/setrun.py
+++ b/examples/euler_1d_wcblast/setrun.py
@@ -250,7 +250,7 @@ def setrun(claw_pkg='amrclaw'):
     amrdata = rundata.amrdata
 
     # max1d controls size of grids
-    amrdata.max1d = 100
+    amrdata.max1d = 500
 
     # max number of refinement levels:
     amrdata.amr_levels_max = 4


### PR DESCRIPTION
There were set to other values for testing, but leave at default as
sample of how to set.

@mjberger:  I suggest changing these back to the default values.  If you agree, please merge it into your branch and it will automatically update https://github.com/clawpack/amrclaw/pull/253